### PR TITLE
Detect Move in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,16 +11,22 @@ chroot_path="${chroot_path:-"/home/$USER/.local/share/debian"}"
 debootstrap_path="${debootstrap_path:-"/home/$USER/.local/share/debootstrap"}"
 debian_variant=${debian_variant:-minbase}
 debian_version=${debian_version:-bullseye}
-if ! [ -f /sys/devices/soc0/machine ]; then
-  debian_arch=${debian_arch:-amd64}
-elif [[ "$(uname -m)" == "aarch64" ]]; then
-  debian_arch=${debian_arch:-arm64}
-elif [[ "$(uname -m)" == "armv7l" ]]; then
-  debian_arch=${debian_arch:-armhf}
-else
-  echo "Unknown architecture $(uname -m)"
-  exit 1
-fi
+machine_arch="$(uname -m)"
+case "$machine_arch" in
+  x86_64)
+    debian_arch=${debian_arch:-amd64}
+    ;;
+  aarch64)
+    debian_arch=${debian_arch:-arm64}
+    ;;
+  armv7l)
+    debian_arch=${debian_arch:-armhf}
+    ;;
+  *)
+    echo "Unknown architecture $machine_arch"
+    exit 1
+    ;;
+esac
 download() {
   if [ -f "$3" ]; then
     echo "Warning: ${3} already exists"

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,15 @@ chroot_path="${chroot_path:-"/home/$USER/.local/share/debian"}"
 debootstrap_path="${debootstrap_path:-"/home/$USER/.local/share/debootstrap"}"
 debian_variant=${debian_variant:-minbase}
 debian_version=${debian_version:-bullseye}
-if ! [ -f /sys/devices/soc0/machine ];then
+if ! [ -f /sys/devices/soc0/machine ]; then
   debian_arch=${debian_arch:-amd64}
-elif [[ "$(cat /sys/devices/soc0/machine)" == "reMarkable Ferrari" ]] || [[ "$(cat /sys/devices/soc0/machine)" == "reMarkable Chiappa" ]]; then
+elif [[ "$(uname -m)" == "aarch64" ]]; then
   debian_arch=${debian_arch:-arm64}
-else
+elif [[ "$(uname -m)" == "armv7l" ]]; then
   debian_arch=${debian_arch:-armhf}
+else
+  echo "Unknown architecture $(uname -m)"
+  exit 1
 fi
 download() {
   if [ -f "$3" ]; then

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ debian_variant=${debian_variant:-minbase}
 debian_version=${debian_version:-bullseye}
 if ! [ -f /sys/devices/soc0/machine ];then
   debian_arch=${debian_arch:-amd64}
-elif [[ "$(cat /sys/devices/soc0/machine)" == "reMarkable Ferrari" ]]; then
+elif [[ "$(cat /sys/devices/soc0/machine)" == "reMarkable Ferrari" ]] || [[ "$(cat /sys/devices/soc0/machine)" == "reMarkable Chiappa" ]]; then
   debian_arch=${debian_arch:-arm64}
 else
   debian_arch=${debian_arch:-armhf}


### PR DESCRIPTION
## Changes
- Set architecture to arm64 if the device name is "reMarkable Chiappa"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer architecture detection and mapping for a wider range of devices (x86_64, aarch64, armv7l).
  * Installer now exits cleanly with an error for unsupported architectures to avoid mis-installs.
  * Preserved existing download and installation behavior beyond architecture detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->